### PR TITLE
xvfb: explicitly listen for incoming TCP connections

### DIFF
--- a/pytest_services/xvfb.py
+++ b/pytest_services/xvfb.py
@@ -24,7 +24,7 @@ def x_version():
         flags=re.MULTILINE,
     ).groupdict()
     version = match['version']
-    return tuple(int(d) for d in version.split('.'))
+    return tuple(int(d) for d in version.split(b'.'))
 
 
 @pytest.fixture(scope='session')

--- a/pytest_services/xvfb.py
+++ b/pytest_services/xvfb.py
@@ -19,7 +19,7 @@ def x_version():
     output = subprocess.check_output(['Xorg', '-version'], stderr=subprocess.STDOUT)
 
     match = re.search(
-        r'^X\.Org X Server (?P<version>[\d\.]+)$',
+        br'^X\.Org X Server (?P<version>[\d\.]+)$',
         output,
         flags=re.MULTILINE,
     ).groupdict()

--- a/pytest_services/xvfb.py
+++ b/pytest_services/xvfb.py
@@ -58,7 +58,8 @@ def xvfb(request, run_services, xvfb_display, lock_dir, xvfb_resolution, watcher
                 'x'.join(str(value) for value in xvfb_resolution),
                 '-ac',
                 '-nolock',
-                '+extension', 'RANDR'
+                '+extension', 'RANDR',
+                '-listen', 'TCP',
             ],
             checker=checker
         )


### PR DESCRIPTION
On some configuration (like on macOS with Xquartz) the Xserver is instantiate with '-nolisten' by default.
This patch explicitly tell Xvfb to listen on TCP socket, otherwise the checker thinks that there is no Xserver running.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/9)
<!-- Reviewable:end -->
