### PR TITLE
Add request to watcher_getter

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 -----
 
 - Add `request` param to watcher_getter to have proper execution order
-  of finalizers.
+  of finalizers (youtux).
 
 1.2.1
 -----

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.3.0
+-----
+
+- Add `request` param to watcher_getter to have proper execution order
+  of finalizers.
+
 1.2.1
 -----
 

--- a/README.rst
+++ b/README.rst
@@ -68,7 +68,10 @@ Infrastructure fixtures
             return watcher_getter(
                 name='memcached',
                 arguments=['-s', memcached_socket],
-                checker=lambda: os.path.exists(memcached_socket))
+                checker=lambda: os.path.exists(memcached_socket),
+                # Needed for the correct execution order of finalizers
+                request=request,
+            )
 
 * services_log
     Logger used for debug logging when managing test services.

--- a/pytest_services/memcached.py
+++ b/pytest_services/memcached.py
@@ -11,13 +11,15 @@ def memcached_socket(run_dir, run_services):
 
 
 @pytest.fixture(scope='session')
-def memcached(run_services, memcached_socket, watcher_getter):
+def memcached(request, run_services, memcached_socket, watcher_getter):
     """The memcached instance which is ready to be used by the tests."""
     if run_services:
         return watcher_getter(
             name='memcached',
             arguments=['-s', memcached_socket],
-            checker=lambda: os.path.exists(memcached_socket))
+            checker=lambda: os.path.exists(memcached_socket),
+            request=request,
+        )
 
 
 @pytest.fixture(scope='session')

--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -103,13 +103,18 @@ def mysql_watcher(
         mysql_defaults_file):
     """The mysqld process watcher."""
     if run_services:
-        return watcher_getter('mysqld', [
-            '--defaults-file={0}'.format(mysql_defaults_file),
-            '--datadir={mysql_data_dir}'.format(mysql_data_dir=mysql_data_dir),
-            '--pid-file={mysql_pid}'.format(mysql_pid=mysql_pid),
-            '--socket={mysql_socket}'.format(mysql_socket=mysql_socket),
-            '--skip-networking',
-        ], checker=lambda: os.path.exists(mysql_socket))
+        return watcher_getter(
+            'mysqld',
+            [
+                '--defaults-file={0}'.format(mysql_defaults_file),
+                '--datadir={mysql_data_dir}'.format(mysql_data_dir=mysql_data_dir),
+                '--pid-file={mysql_pid}'.format(mysql_pid=mysql_pid),
+                '--socket={mysql_socket}'.format(mysql_socket=mysql_socket),
+                '--skip-networking',
+            ],
+            checker=lambda: os.path.exists(mysql_socket),
+            request=request,
+        )
 
 
 @pytest.fixture(scope='session')

--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -120,7 +120,7 @@ def mysql_watcher(
 @pytest.fixture(scope='session')
 def mysql_database_name():
     """Name of test database to be created."""
-    return 'test'
+    return 'pytest_services_test'
 
 
 @pytest.fixture(scope='session')

--- a/pytest_services/service.py
+++ b/pytest_services/service.py
@@ -1,7 +1,7 @@
 """Service fixtures."""
 import time
 import re
-import warning
+import warnings
 try:
     import subprocess32 as subprocess
 except ImportError:  # pragma: no cover
@@ -60,7 +60,7 @@ def watcher_getter(request, services_log):
     orig_request = request
     def watcher_getter_function(name, arguments=None, kwargs=None, timeout=20, checker=None, request=None):
         if request is None:
-            warning.warn('Omitting the `request` parameter will result in an '
+            warnings.warn('Omitting the `request` parameter will result in an '
                          'unstable order of finalizers.')
             request = orig_request
         executable = find_executable(name)

--- a/pytest_services/service.py
+++ b/pytest_services/service.py
@@ -1,6 +1,7 @@
 """Service fixtures."""
 import time
 import re
+import warning
 try:
     import subprocess32 as subprocess
 except ImportError:  # pragma: no cover
@@ -56,7 +57,12 @@ def watcher_getter(request, services_log):
     Wait for the process to start.
     Add finalizer to properly stop it.
     """
-    def watcher_getter_function(name, arguments=None, kwargs=None, timeout=20, checker=None):
+    orig_request = request
+    def watcher_getter_function(name, arguments=None, kwargs=None, timeout=20, checker=None, request=None):
+        if request is None:
+            warning.warn('Omitting the `request` parameter will result in an '
+                         'unstable order of finalizers.')
+            request = orig_request
         executable = find_executable(name)
         assert executable, 'You have to install {0} executable.'.format(name)
 
@@ -80,7 +86,7 @@ def watcher_getter(request, services_log):
                     watcher.communicate(timeout=timeout / 2)
         request.addfinalizer(finalize)
 
-        # Wait for memcached to accept connections.
+        # Wait for the service to start.
         times = 0
         while not checker():
             if watcher.returncode is not None:

--- a/pytest_services/xvfb.py
+++ b/pytest_services/xvfb.py
@@ -91,4 +91,5 @@ def xvfb(request, run_services, xvfb_display, lock_dir, xvfb_resolution, watcher
                 '+extension', 'RANDR'
             ] + listen_args,
             checker=checker,
+            request=request,
         )


### PR DESCRIPTION
Currently, watcher_getter attaches the process killer function to its own request, resulting in an wrong execution order of the finalizers.
This PR addresses the issue by allowing to pass a `request` object to the watcher_getter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/21)
<!-- Reviewable:end -->
