### PR TITLE
Improved Windows support

### DIFF
--- a/pytest_services/locks.py
+++ b/pytest_services/locks.py
@@ -1,11 +1,17 @@
 """Fixtures for supporting a distributed test run."""
 import contextlib
 import errno
-import fcntl
 import json
 import os
 import socket
 import time
+
+try:
+    import fcntl
+except ImportError:
+    class fcntl:
+        LOCK_EX = None
+        LOCK_UN = None
 
 import pytest
 

--- a/pytest_services/log.py
+++ b/pytest_services/log.py
@@ -16,7 +16,7 @@ def services_log(slave_id):
             handler = logging.handlers.SysLogHandler(
                 facility=logging.handlers.SysLogHandler.LOG_LOCAL7, address='/dev/log', **kwargs)
             break
-        except (IOError, TypeError):
+        except (IOError, TypeError, AttributeError):
             pass
     logger = logging.getLogger('[{slave_id}] {name}'.format(name=__name__, slave_id=slave_id))
     logger.setLevel(logging.DEBUG)

--- a/pytest_services/xvfb.py
+++ b/pytest_services/xvfb.py
@@ -1,12 +1,16 @@
 """Fixtures for the GUI environment."""
 import os
-import fcntl
 import socket
 import re
 try:
     import subprocess32 as subprocess
 except ImportError:  # pragma: no cover
     import subprocess
+
+try:
+    import fcntl
+except ImportError:
+    pass
 
 import pytest
 


### PR DESCRIPTION
This commit improves viability of pytest-services on Windows by minimally suppressing errors on Import and an AttributeError that occurs in log.py.

With these changes, CherryPy can rely on the watcher_getter in services, even on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/24)
<!-- Reviewable:end -->
