### PR TITLE
Flush file before unlocking it

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.3.1
+-----
+
+- Fix race condition causing when using port_getter/display_getter (youtux)
+
+
 1.3.0
 -----
 

--- a/pytest_services/__init__.py
+++ b/pytest_services/__init__.py
@@ -1,2 +1,2 @@
 """pytest-services package."""
-__version__ = '1.3.0'
+__version__ = '1.3.1'

--- a/pytest_services/locks.py
+++ b/pytest_services/locks.py
@@ -112,6 +112,7 @@ def locked_resources(name, lock_dir):
         fd.seek(0)
         fd.truncate()
         fd.write(json.dumps(bound_resources))
+        fd.flush()
 
 
 def unlock_port(port, lock_dir, services_log):


### PR DESCRIPTION
With the current implementation, there is a race condition when the lock file is unlocked but the changes have not been flushed yet, resulting in a second process reading the old version of the file.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/25)
<!-- Reviewable:end -->
