### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ python: "2.7"
 
 matrix:
   include:
-  - env: TOXENV=py27-pytestlatest-linters
+  - env: TOXENV=linters
   - env: TOXENV=py27-pytest30
   - env: TOXENV=py27-pytest31
   - env: TOXENV=py27-pytest32

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,12 @@ matrix:
     python: "3.5"
   - env: TOXENV=py36-pytestlatest
     python: "3.6"
+  - env: TOXENV=py37-pytestlatest
+    python: "3.7"
+    # Currently, python 3.7 is a little bit tricky to install:
+    # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
+    sudo: required
+    dist: xenial
   - env: TOXENV=py27-pytestlatest-coveralls
 install: pip install tox
 # mysql_install_db will not work if it can't find the my-default.cnf file

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ env:
     - TESTENV=coveralls
 install:
   - pip install tox
+# mysql_install_db will not work if it can't find the my-default.cnf file
+before_script: sudo cp /etc/mysql/my.cnf /usr/share/mysql/my-default.cnf
 script: tox -e $TESTENV
 branches:
   except:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,6 @@ matrix:
     python: "3.5"
   - env: TOXENV=py36-pytestlatest
     python: "3.6"
-  - env: TOXENV=py37-pytestlatest
-    python: "3.7"
-    # Currently, python 3.7 is a little bit tricky to install:
-    # https://github.com/travis-ci/travis-ci/issues/9069#issuecomment-425720905
-    sudo: required
-    dist: xenial
   - env: TOXENV=py27-pytestlatest-coveralls
 install: pip install tox
 # mysql_install_db will not work if it can't find the my-default.cnf file

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,37 @@
 sudo: false
 language: python
-python: "3.4"
-env:
-  matrix:
-    - TESTENV=linters
-    - TESTENV=py27
-    - TESTENV=py27-xdist
-    - TESTENV=py27-pytest-latest
-    - TESTENV=py34
-    - TESTENV=coveralls
-install:
-  - pip install tox
+python: "2.7"
+
+matrix:
+  include:
+  - env: TOXENV=py27-pytestlatest-linters
+  - env: TOXENV=py27-pytest30
+  - env: TOXENV=py27-pytest31
+  - env: TOXENV=py27-pytest32
+  - env: TOXENV=py27-pytest33
+  - env: TOXENV=py27-pytest34
+  - env: TOXENV=py27-pytest35
+  - env: TOXENV=py27-pytest36
+  - env: TOXENV=py27-pytest37
+  - env: TOXENV=py27-pytest38
+  - env: TOXENV=py27-pytest39
+  - env: TOXENV=py27-pytest310
+  - env: TOXENV=py27-pytestlatest
+  - env: TOXENV=py27-pytestlatest-xdist
+  - env: TOXENV=py34-pytestlatest
+    python: "3.4"
+  - env: TOXENV=py35-pytestlatest
+    python: "3.5"
+  - env: TOXENV=py36-pytestlatest
+    python: "3.6"
+  - env: TOXENV=py27-pytestlatest-coveralls
+install: pip install tox
 # mysql_install_db will not work if it can't find the my-default.cnf file
 before_script: sudo cp /etc/mysql/my.cnf /usr/share/mysql/my-default.cnf
-script: tox -e $TESTENV
+script: tox
 branches:
   except:
-    - /^\d/
+  - /^\d/
 notifications:
   email:
   - bubenkoff@gmail.com

--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -50,9 +50,6 @@ def mysql_system_database(
         mysql_install_db = find_executable('mysql_install_db')
         assert mysql_install_db, 'You have to install mysql_install_db script.'
 
-        my_print_defaults = find_executable('my_print_defaults')
-        assert my_print_defaults, 'You have to install my_print_defaults script.'
-
         try:
             services_log.debug('Starting mysql_install_db.')
             check_output([

--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -28,7 +28,23 @@ default-time-zone = SYSTEM
 
 
 @pytest.fixture(scope='session')
-def mysql_system_database(run_services, mysql_data_dir, mysql_defaults_file, memory_temp_dir, lock_dir, services_log):
+def mysql_base_dir():
+    my_print_defaults = find_executable('my_print_defaults')
+    assert my_print_defaults, 'You have to install my_print_defaults script.'
+
+    return os.path.dirname(os.path.dirname(os.path.realpath(my_print_defaults)))
+
+
+@pytest.fixture(scope='session')
+def mysql_system_database(
+        run_services,
+        mysql_data_dir,
+        mysql_base_dir,
+        mysql_defaults_file,
+        memory_temp_dir,
+        lock_dir,
+        services_log,
+):
     """Install database to given path."""
     if run_services:
         mysql_install_db = find_executable('mysql_install_db')
@@ -37,15 +53,13 @@ def mysql_system_database(run_services, mysql_data_dir, mysql_defaults_file, mem
         my_print_defaults = find_executable('my_print_defaults')
         assert my_print_defaults, 'You have to install my_print_defaults script.'
 
-        mysql_basedir = os.path.dirname(os.path.dirname(os.path.realpath(my_print_defaults)))
-
         try:
             services_log.debug('Starting mysql_install_db.')
             check_output([
                 mysql_install_db,
                 '--defaults-file={0}'.format(mysql_defaults_file),
                 '--datadir={0}'.format(mysql_data_dir),
-                '--basedir={0}'.format(mysql_basedir),
+                '--basedir={0}'.format(mysql_base_dir),
                 '--user={0}'.format(os.environ['USER'])
             ])
         except CalledProcessWithOutputError as e:

--- a/pytest_services/service.py
+++ b/pytest_services/service.py
@@ -58,10 +58,10 @@ def watcher_getter(request, services_log):
     Add finalizer to properly stop it.
     """
     orig_request = request
+
     def watcher_getter_function(name, arguments=None, kwargs=None, timeout=20, checker=None, request=None):
         if request is None:
-            warnings.warn('Omitting the `request` parameter will result in an '
-                         'unstable order of finalizers.')
+            warnings.warn('Omitting the `request` parameter will result in an unstable order of finalizers.')
             request = orig_request
         executable = find_executable(name)
         assert executable, 'You have to install {0} executable.'.format(name)

--- a/requirements-testing.txt
+++ b/requirements-testing.txt
@@ -4,6 +4,4 @@ mock
 mysqlclient
 pylibmc
 pytest-pep8
-pylama
-pylama_pylint
 astroid

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         'Topic :: Utilities',
         'Programming Language :: Python :: 2',
         'Programming Language :: Python :: 3',
-    ] + [('Programming Language :: Python :: %s' % x) for x in '2.7 3.0 3.1 3.2 3.3 3.4'.split()],
+    ] + [('Programming Language :: Python :: %s' % x) for x in '2.7 3.4 3.5 3.6 3.7'.split()],
     tests_require=['tox'],
     entry_points={'pytest11': [
         'pytest-services=pytest_services.plugin',

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -13,7 +13,7 @@ def test_memcached(request, memcached, memcached_socket):
     assert mc.get('some') == 1
 
     # check memcached cleaner
-    request.getfuncargvalue('memcached_clean')
+    request.getfixturevalue('memcached_clean')
     assert mc.get('some') is None
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ deps =
     {[testenv]deps}
     coveralls
 commands=
-    coverage run --source=pytest_services -m pytest tests
+    coverage run --source=pytest_services --branch -m pytest tests
     coverage report -m
     coveralls
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ extras = memcache
 
 [testenv:linters]
 basepython=python2.7
-commands={[testenv]commands} pytest_services --pylama
+commands={[testenv]commands} pytest_services --pep8 -m pep8
 
 [testenv:coveralls]
 deps =
@@ -41,19 +41,5 @@ deps =
     git+https://github.com/pytest-dev/pytest.git@features#egg=pytest
 
 [pytest]
+pep8maxlinelength=120
 addopts = -vvl
-
-[pylama]
-format = pep8
-skip = */.tox/*,*/.env/*
-linters = pylint,mccabe,pep8,pep257
-ignore = F0401,C0111,E731,D100,W0621,W0108,R0201,W0401,W0614,W0212,C901,R0914,I0011,D211
-
-[pylama:pep8]
-max_line_length = 120
-
-[pylama:pylint]
-max_line_length = 120
-
-[pylama:mccabe]
-max_complexity = 11

--- a/tox.ini
+++ b/tox.ini
@@ -33,11 +33,12 @@ basepython=python2.7
 commands={[testenv]commands} pytest_services --pep8 -m pep8
 
 [testenv:py27-pytestlatest-coveralls]
+usedevelop = True
 deps =
     {[testenv]deps}
     coveralls
 commands=
-    coverage run --source=pytest_services {envdir}/bin/py.test tests
+    coverage run --source=pytest_services -m pytest tests
     coverage report -m
     coveralls
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ distshare={homedir}/.tox/distshare
 envlist=
     linters
     py27-pytest{30,31,32,33,34,35,36,37,38,39,310,latest}
-    py{34,35,36,37}-pytestlatest
+    py{34,35,36}-pytestlatest
     py27-pytestlatest-xdist
     py27-pytestlatest-coveralls
 skip_missing_interpreters = true

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,29 @@
 [tox]
 distshare={homedir}/.tox/distshare
-envlist=linters,py27,py27-xdist,py27-pytest-latest,py34
+envlist=
+    linters
+    py27-pytest{30,31,32,33,34,35,36,37,38,39,310,latest}
+    py{34,35,36}-pytestlatest
+    py27-pytestlatest-xdist
+    py27-pytestlatest-coveralls
 skip_missing_interpreters = true
 
 [testenv]
 commands= py.test tests --junitxml={envlogdir}/junit-{envname}.xml
 deps =
-    -e.
+    pytestlatest: pytest
+    pytest310: pytest~=3.10.0
+    pytest39: pytest~=3.9.0
+    pytest38: pytest~=3.8.0
+    pytest37: pytest~=3.7.0
+    pytest36: pytest~=3.6.0
+    pytest35: pytest~=3.5.0
+    pytest34: pytest~=3.4.0
+    pytest33: pytest~=3.3.0
+    pytest32: pytest~=3.2.0
+    pytest31: pytest~=3.1.0
+    pytest30: pytest~=3.0.0
+    xdist: pytest-xdist
     -r{toxinidir}/requirements-testing.txt
 passenv = DISPLAY COVERALLS_REPO_TOKEN USER TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 extras = memcache
@@ -15,7 +32,7 @@ extras = memcache
 basepython=python2.7
 commands={[testenv]commands} pytest_services --pep8 -m pep8
 
-[testenv:coveralls]
+[testenv:py27-pytestlatest-coveralls]
 deps =
     {[testenv]deps}
     coveralls
@@ -24,21 +41,8 @@ commands=
     coverage report -m
     coveralls
 
-[testenv:py27-xdist]
-basepython=python2.7
-deps =
-    {[testenv]deps}
-    pytest-xdist
-commands=
-  py.test tests -n1 -rfsxX \
-        --junitxml={envlogdir}/junit-{envname}.xml
-
-[testenv:py27-pytest-latest]
-basepython=python2.7
-deps =
-    {[testenv]deps}
-    git+https://github.com/pytest-dev/py.git@master#egg=py
-    git+https://github.com/pytest-dev/pytest.git@features#egg=pytest
+[testenv:py27-pytestlatest-xdist]
+commands={[testenv]commands} -n1 -rfsxX
 
 [pytest]
 pep8maxlinelength=120

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ distshare={homedir}/.tox/distshare
 envlist=
     linters
     py27-pytest{30,31,32,33,34,35,36,37,38,39,310,latest}
-    py{34,35,36}-pytestlatest
+    py{34,35,36,37}-pytestlatest
     py27-pytestlatest-xdist
     py27-pytestlatest-coveralls
 skip_missing_interpreters = true


### PR DESCRIPTION
CI builds were broken for quite some time due to changes in travis. The main issue was a file `my-default.cnf` missing and I made a workaround for that in `.travis.yml:before_script`.

I also extended the travis matrix to have more coverage with various pytests/pythons.

I removed pytest-pylama and replaced it with just pytest-pep8, in order to avoid getting crazy with conflicting styling guides ([this in particular](https://github.com/PyCQA/pydocstyle/issues/242#issuecomment-288166773)).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/26)
<!-- Reviewable:end -->
