### PR TITLE
Switch to mysqld --initialize as mysql_install_db is deprecated

### DIFF
--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -47,13 +47,14 @@ def mysql_system_database(
 ):
     """Install database to given path."""
     if run_services:
-        mysql_install_db = find_executable('mysql_install_db')
-        assert mysql_install_db, 'You have to install mysql_install_db script.'
+        mysqld = find_executable('mysqld')
+        assert mysqld, 'You have to install mysqld script.'
 
         try:
-            services_log.debug('Starting mysql_install_db.')
+            services_log.debug('Starting mysqld.')
             check_output([
-                mysql_install_db,
+                mysqld,
+                '--initialize',
                 '--defaults-file={0}'.format(mysql_defaults_file),
                 '--datadir={0}'.format(mysql_data_dir),
                 '--basedir={0}'.format(mysql_base_dir),
@@ -65,7 +66,7 @@ def mysql_system_database(
                 'Please ensure you disabled apparmor for /run/shm/** or for whole mysql'.format(e=e))
             raise
         finally:
-            services_log.debug('mysql_install_db was executed.')
+            services_log.debug('mysqld was executed.')
 
 
 @pytest.fixture(scope='session')

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist=
 skip_missing_interpreters = true
 
 [testenv]
-commands= py.test tests --junitxml={envlogdir}/junit-{envname}.xml
+commands= py.test tests --junitxml={envlogdir}/junit-{envname}.xml {posargs}
 deps =
     pytestlatest: pytest
     pytest310: pytest~=3.10.0


### PR DESCRIPTION
Fixes #28

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/30)
<!-- Reviewable:end -->
