### PR TITLE
Remove unnecessary install_requires on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ long_description = (
 )
 
 install_requires = [
-    'setuptools',
     'requests',
     'psutil',
     'pytest',


### PR DESCRIPTION
Remove the explicit runtime dependency on setuptools.  None
of the packages installed by setuptools seem to be used by the package.
While arguably the pytest entry point might require setuptools but then
the dependency belongs (and is present) in pytest, especially that
a future version may use a different entry point loader.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/41)
<!-- Reviewable:end -->
