### PR TITLE
Add zc.lockfile.LockError handling to locks.file_lock

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,6 +10,7 @@ These people have contributed to `pytest-services`, in alphabetical order:
 * `Dmitrijs Milajevs <dimazest@gmail.com>`_
 * `Jason R. Coombs <jaraco@jaraco.com>`_
 * `Joep van Dijken <joepvandijken@github.com>`_
+* `Magnus Staberg <magnus@staberg.io>`_
+* `Michael Shriver <mshriver@redhat.com>`_
 * `Oleg Pidsadnyi <oleg.pidsadnyi@gmail.com>`_
 * `Zac Hatfield-Dodds <zac@zhd.dev>`_
-* `Magnus Staberg <magnus@staberg.io>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+Unreleased
+-----
+
+- #42: Retry on ``zc.lockfile.LockError`` in ``file_lock``, use existing timeout kwarg
+
 2.2.0
 -----
 


### PR DESCRIPTION
Following @StabbarN lead for issue #38 and fix in #39, I added a timeout loop and exception handling for the exception raised by zc.lockfile.

Working on getting tox to run for your unit tests, figured I would open the PR in the meanwhile.

Testing against SatelliteQE/Robottelo unit tests where this was encountered after the update to pytest-services 2.2.0 is successful, for what its worth.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/42)
<!-- Reviewable:end -->
