### PR TITLE
Replace distutils.spawn.find_executable with shutil.which

### DIFF
--- a/pytest_services/gui.py.orig
+++ b/pytest_services/gui.py.orig
@@ -7,7 +7,7 @@ import socket
 import shlex
 import subprocess32
 
-from distutils.spawn import find_executable
+from shutil import which
 import pytest
 
 from tests.fixtures.services.util import (
@@ -70,7 +70,7 @@ def xvfb_watcher(
         with file_lock(
                 os.path.join(lock_dir, 'xvfb_{0}.lock'.format(display)),
                 operation=fcntl.LOCK_EX | fcntl.LOCK_NB):
-            xvfb = find_executable('Xvfb')
+            xvfb = which('Xvfb')
             assert xvfb, 'You have to have Xvfb installed'
             cmd = (
                 '{xvfb} '

--- a/pytest_services/mysql.py
+++ b/pytest_services/mysql.py
@@ -2,7 +2,6 @@
 import os
 import shutil
 
-from distutils.spawn import find_executable  # pylint: disable=E0611
 import pytest
 
 from .process import (
@@ -31,7 +30,7 @@ default-time-zone = SYSTEM
 
 @pytest.fixture(scope='session')
 def mysql_base_dir():
-    my_print_defaults = find_executable('my_print_defaults')
+    my_print_defaults = shutil.which('my_print_defaults')
     assert my_print_defaults, 'You have to install my_print_defaults script.'
 
     return os.path.dirname(os.path.dirname(os.path.realpath(my_print_defaults)))

--- a/pytest_services/service.py
+++ b/pytest_services/service.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
     import subprocess
 import uuid  # pylint: disable=C0411
 
-from distutils.spawn import find_executable  # pylint: disable=E0611
+from shutil import which
 import pytest
 
 WRONG_FILE_NAME_CHARS_RE = re.compile(r'[^\w_-]')
@@ -70,7 +70,7 @@ def watcher_getter(request, services_log):
         if request is None:
             warnings.warn('Omitting the `request` parameter will result in an unstable order of finalizers.')
             request = orig_request
-        executable = find_executable(name)
+        executable = which(name)
         assert executable, 'You have to install {0} executable.'.format(name)
 
         cmd = [name] + (arguments or [])


### PR DESCRIPTION
The package distutils is deprecated and slated for removal in Python 3.12.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/46)
<!-- Reviewable:end -->
