### PR TITLE
Replace distutils.spawn.find_executable with shutil.which

### DIFF
--- a/pytest_services/gui.py.orig
+++ b/pytest_services/gui.py.orig
@@ -7,7 +7,7 @@ import socket
 import shlex
 import subprocess32
 
-from distutils.spawn import find_executable
+from shutil import which
 import pytest
 
 from tests.fixtures.services.util import (
@@ -70,7 +70,7 @@ def xvfb_watcher(
         with file_lock(
                 os.path.join(lock_dir, 'xvfb_{0}.lock'.format(display)),
                 operation=fcntl.LOCK_EX | fcntl.LOCK_NB):
-            xvfb = find_executable('Xvfb')
+            xvfb = which('Xvfb')
             assert xvfb, 'You have to have Xvfb installed'
             cmd = (
                 '{xvfb} '

--- a/pytest_services/service.py
+++ b/pytest_services/service.py
@@ -8,7 +8,7 @@ except ImportError:  # pragma: no cover
     import subprocess
 import uuid  # pylint: disable=C0411
 
-from distutils.spawn import find_executable  # pylint: disable=E0611
+from shutil import which
 import pytest
 
 WRONG_FILE_NAME_CHARS_RE = re.compile(r'[^\w_-]')
@@ -70,7 +70,7 @@ def watcher_getter(request, services_log):
         if request is None:
             warnings.warn('Omitting the `request` parameter will result in an unstable order of finalizers.')
             request = orig_request
-        executable = find_executable(name)
+        executable = which(name)
         assert executable, 'You have to install {0} executable.'.format(name)
 
         cmd = [name] + (arguments or [])


### PR DESCRIPTION
The package distutils is deprecated and caues DeprecationWarnings. Replaced its usage with shutil.which.

Similar to a previous pull request that was closed before being merged: https://github.com/pytest-dev/pytest-services/pull/46

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/47)
<!-- Reviewable:end -->
