### PR TITLE
Move third-party library imports to specific tests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+- #52: Move ``pylibmc`` and ``MySQLdb`` library imports to specific tests -- this makes it easier to test a subset of the ``pytest-services`` package  without having to install all the dependencies.
+
 2.2.2
 -----
 

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -2,12 +2,11 @@
 import os.path
 import socket
 
-import pylibmc
-import MySQLdb
-
 
 def test_memcached(request, memcached, memcached_socket):
     """Test memcached service."""
+    import pylibmc
+
     mc = pylibmc.Client([memcached_socket])
     mc.set('some', 1)
     assert mc.get('some') == 1
@@ -19,6 +18,8 @@ def test_memcached(request, memcached, memcached_socket):
 
 def test_mysql(mysql, mysql_connection, mysql_socket):
     """Test mysql service."""
+    import MySQLdb
+
     conn = MySQLdb.connect(user='root', unix_socket=mysql_socket)
     assert conn
 


### PR DESCRIPTION
Move third-party (`pylibmc` and `MySQLdb`) imports to specific tests, rather than importing them in global scope.  This makes it easier to test a subset of the package without having to install all the dependencies, which can be particularly problematic when wheels are not provided (e.g. on PyPy3.11 or CPython 3.14).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pytest-dev/pytest-services/52)
<!-- Reviewable:end -->
